### PR TITLE
Add lib and refactor chess module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ axum = "0.8.1"
 serde = { version = "1.0.217", features = ["derive"] }
 tokio = { version = "1.43.0", features = ["full"] }
 
+[lib]
+name = "lib_openchess"
+path = "src/lib.rs"
+
 [[bin]]
 name = "openchess-rs"
 path = "src/main.rs"

--- a/src/chess.rs
+++ b/src/chess.rs
@@ -144,7 +144,9 @@ impl Board {
 }
 
 impl IntoSvg for Board {
-    fn into_svg(self: Self) -> String {
+    type Options = ();
+
+    fn into_svg(self: Self, _: Self::Options) -> String {
         todo!()
     }
 }

--- a/src/chess.rs
+++ b/src/chess.rs
@@ -1,3 +1,57 @@
+use serde::Deserialize;
+
+use crate::{IntoBoard, IntoSvg};
+
+#[derive(Deserialize)]
+pub struct Fen(String);
+
+impl IntoBoard for Fen {
+    type Board = Board;
+
+    fn into_board(self: Self) -> Result<Self::Board, String> {
+        let mut board = Board::new();
+
+        // Isolate the piece positions from the rest of FEN notation
+        let board_part = self.0.split_whitespace().next().unwrap_or(self.0.as_ref());
+
+        // Split the piece positions by row
+        let rows: Vec<&str> = board_part.split('/').collect();
+
+        if rows.len() != 8 {
+            return Err(format!("Invalid FEN: must have 8 rows"));
+        }
+
+        // Process each char of each row
+        for (row_index, row) in rows.iter().enumerate() {
+            let mut col_index = 0;
+
+            for c in row.chars() {
+                if col_index == 8 {
+                    // The row contains information for too many pieces (>8)
+                    return Err(format!("Invalid FEN: row: {row}"));
+                } else if c.is_ascii_digit() {
+                    if let Some(digit) = c.to_digit(10) {
+                        if digit < 1 || digit > (8 - col_index) {
+                            // The digit in the row claimed 0 or too many empty pieces
+                            return Err(format!("Invalid FEN: row: {row}"));
+                        }
+                        col_index += digit;
+                    } else {
+                        return Err(format!("Character {c} failed to convert to digit"));
+                    }
+                } else {
+                    let piece = Piece::from_char(c)?;
+                    // Shift PieceState value left col columns and bitwise OR with current row state
+                    board.set_piece(row_index as u32, col_index, piece);
+                    col_index += 1;
+                }
+            }
+        }
+
+        Ok(board)
+    }
+}
+
 /// Chess pieces
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
@@ -17,77 +71,9 @@ pub enum Piece {
     BKing = 13,
 }
 
-/// Board state structure
-#[derive(Clone, Copy, Debug)]
-pub struct Board {
-    rows: [u32; 8], // 8 rows of 32 bits, each piece is allocated 4 bits to represent 13 possible states
-}
-
-impl Board {
-    /// Initializes a new ChessBoard with empty pieces 
-    pub fn new() -> Self {
-        Self { rows: [0; 8] }
-    }
-
-    /// Initializes a new ChessBoard from FEN notation
-    pub fn from_fen(fen: &str) -> Result<Self, String> {
-        let mut board = Board::new();
-        
-        // Isolate the piece positions from the rest of FEN notation
-        let board_part = fen.split_whitespace().next().unwrap_or(fen);
-        
-        // Split the piece positions by row
-        let rows: Vec<&str> = board_part.split('/').collect();
-
-        if rows.len() != 8 {
-            return Err(format!("Invalid FEN: must have 8 rows"));
-        }
-
-        // Process each char of each row
-        for (row_index, row) in rows.iter().enumerate() {
-            let mut col_index = 0;
-
-            for c in row.chars() {
-                if col_index == 8 {
-                    // The row contains information for too many pieces (>8)
-                    return Err(format!("Invalid FEN: row: {row}"))
-                } else if c.is_ascii_digit() {
-                    if let Some(digit) = c.to_digit(10) {
-                        if digit < 1 || digit > (8 - col_index) {
-                            // The digit in the row claimed 0 or too many empty pieces
-                            return Err(format!("Invalid FEN: row: {row}"));
-                        }
-                        col_index += digit;
-                    }
-                    else{
-                        return Err(format!("Character {c} failed to convert to digit"));
-                    }
-                } else {
-                    let piece = Self::piece_from_char(c)?;
-                    // Shift PieceState value left col columns and bitwise OR with current row state
-                    board.rows[row_index] |= (piece as u32) << Self::col_shift(col_index);
-                    col_index += 1;
-                }
-            }
-        }
-
-        Ok(board)
-    }
-    
-    /// Returns an amount to shift a PieceState value to affect the desired column
-    fn col_shift(col: u32) -> u32 {
-        col * 4 // each piece is allocated 4 bits
-    }
-
-    /// Returns a mask that singles out the desired column
-    /// e.g. col 0: 0x0000000F
-    /// e.g. col 7: 0xF0000000
-    fn col_mask(col: u32) -> u32 {
-        0xF << Self::col_shift(col)
-    }
-
+impl Piece {
     /// Maps FEN piece notation to PieceState Enum
-    fn piece_from_char(c: char) -> Result<Piece, String> {
+    fn from_char(c: char) -> Result<Piece, String> {
         match c {
             'P' => Ok(Piece::WPawn),
             'p' => Ok(Piece::BPawn),
@@ -101,30 +87,65 @@ impl Board {
             'q' => Ok(Piece::BQueen),
             'K' => Ok(Piece::WKing),
             'k' => Ok(Piece::BKing),
-            _   => Err(format!("Invalid FEN: piece character: {c}")),
+            _ => Err(format!("Invalid FEN: piece character: {c}")),
         }
+    }
+}
+
+/// Board state structure
+#[derive(Clone, Copy, Debug)]
+pub struct Board {
+    rows: [u32; 8], // 8 rows of 32 bits, each piece is allocated 4 bits to represent 13 possible states
+}
+
+impl Board {
+    /// Initializes a new ChessBoard with empty pieces
+    pub fn new() -> Self {
+        Self { rows: [0; 8] }
+    }
+
+    /// Returns an amount to shift a PieceState value to affect the desired column
+    fn col_shift(col: u32) -> u32 {
+        col * 4 // each piece is allocated 4 bits
+    }
+
+    /// Returns a mask that singles out the desired column
+    /// e.g. col 0: 0x0000000F
+    /// e.g. col 7: 0xF0000000
+    fn col_mask(col: u32) -> u32 {
+        0xF << Self::col_shift(col)
     }
 
     /// Returns the PieceState at the given position
     pub fn get_piece(&self, row: u32, col: u32) -> Piece {
         // mask the column from the row then shift to lower 4 bits
-        let nibble = (self.rows[row as usize] & Self::col_mask(col)) >> Self::col_shift(col); 
+        let nibble = (self.rows[row as usize] & Self::col_mask(col)) >> Self::col_shift(col);
         match nibble {
-            0  => Piece::Empty,
-            2  => Piece::WPawn,
-            3  => Piece::BPawn,
-            4  => Piece::WKnight,
-            5  => Piece::BKnight,
-            6  => Piece::WBishop,
-            7  => Piece::BBishop,
-            8  => Piece::WRook,
-            9  => Piece::BRook,
+            0 => Piece::Empty,
+            2 => Piece::WPawn,
+            3 => Piece::BPawn,
+            4 => Piece::WKnight,
+            5 => Piece::BKnight,
+            6 => Piece::WBishop,
+            7 => Piece::BBishop,
+            8 => Piece::WRook,
+            9 => Piece::BRook,
             10 => Piece::WQueen,
             11 => Piece::BQueen,
             12 => Piece::WKing,
             13 => Piece::BKing,
-            _  => unreachable!("Invalid nibble: {}", nibble),
+            _ => unreachable!("Invalid nibble: {}", nibble),
         }
+    }
+
+    pub fn set_piece(self: &mut Self, row: u32, col: u32, piece: Piece) -> () {
+        self.rows[row as usize] |= (piece as u32) << Self::col_shift(col);
+    }
+}
+
+impl IntoSvg for Board {
+    fn into_svg(self: Self) -> String {
+        String::new()
     }
 }
 
@@ -133,19 +154,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_new(){
+    fn test_new() {
         let board = Board::new();
-        for y in 0..8{
-            for x in 0..8{
-                assert!(matches!(board.get_piece(x,y), Piece::Empty));
+        for y in 0..8 {
+            for x in 0..8 {
+                assert!(matches!(board.get_piece(x, y), Piece::Empty));
             }
         }
     }
 
     #[test]
-    fn test_from_fen(){
-        let fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR";
-        let board = Board::from_fen(fen).unwrap();
+    fn test_into_board() {
+        let fen = Fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR".to_owned());
+        let board = fen.into_board().unwrap();
 
         // black top
         assert!(matches!(board.get_piece(0, 0), Piece::BRook));
@@ -156,7 +177,7 @@ mod tests {
         assert!(matches!(board.get_piece(0, 5), Piece::BBishop));
         assert!(matches!(board.get_piece(0, 6), Piece::BKnight));
         assert!(matches!(board.get_piece(0, 7), Piece::BRook));
-        
+
         // black pawns
         for x in 0..8 {
             assert!(matches!(board.get_piece(1, x), Piece::BPawn));
@@ -186,42 +207,49 @@ mod tests {
     }
 
     #[test]
-    fn test_from_fen_not_enough_rows(){
-        let fen = "8/8/8/8/8/8/8";
-        let result = Board::from_fen(fen);
+    fn test_into_board_not_enough_rows() {
+        let fen = Fen("8/8/8/8/8/8/8".to_owned());
+        let result = fen.into_board();
+
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "Invalid FEN: must have 8 rows");
     }
 
     #[test]
-    fn test_from_fen_too_many_rows() {
-        let fen = "8/8/8/8/8/8/8/8/8";
-        let result = Board::from_fen(fen);
+    fn test_into_board_too_many_rows() {
+        let fen = Fen("8/8/8/8/8/8/8/8/8".to_owned());
+        let result = fen.into_board();
+
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "Invalid FEN: must have 8 rows");
     }
 
     #[test]
-    fn test_from_fen_row_too_many_columns() {
-        let fen = "8/8/8/8/8/8/ppppppppp/8";
-        let result = Board::from_fen(fen);
+    fn test_into_board_row_too_many_columns() {
+        let fen = Fen("8/8/8/8/8/8/ppppppppp/8".to_owned());
+        let result = fen.into_board();
+
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Invalid FEN: row: ppppppppp"));
     }
 
     #[test]
-    fn test_from_fen_invalid_piece_char() {
+    fn test_into_board_invalid_piece_char() {
         // 'x' is not a valid FEN character
-        let fen = "8/8/8/8/8/8/8/rnbqkbnx";
-        let result = Board::from_fen(fen);
+        let fen = Fen("8/8/8/8/8/8/8/rnbqkbnx".to_owned());
+        let result = fen.into_board();
+
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid FEN: piece character: x"));
+        assert!(result
+            .unwrap_err()
+            .contains("Invalid FEN: piece character: x"));
     }
 
     #[test]
-    fn test_from_fen_digit_too_large_for_remaining_columns() {
-        let fen = "8/8/8/8/8/8/8/9";
-        let result = Board::from_fen(fen);
+    fn test_into_board_digit_too_large_for_remaining_columns() {
+        let fen = Fen("8/8/8/8/8/8/8/9".to_owned());
+        let result = fen.into_board();
+
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Invalid FEN: row: 9"));
     }

--- a/src/chess.rs
+++ b/src/chess.rs
@@ -145,7 +145,7 @@ impl Board {
 
 impl IntoSvg for Board {
     fn into_svg(self: Self) -> String {
-        String::new()
+        todo!()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,9 @@ pub trait IntoBoard {
 }
 
 pub trait IntoSvg {
-    fn into_svg(self: Self) -> String;
+    type Options;
+
+    fn into_svg(self: Self, options: Self::Options) -> String;
 }
 
 pub mod chess;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,11 @@
+pub trait IntoBoard {
+    type Board;
+
+    fn into_board(self: Self) -> Result<Self::Board, String>;
+}
+
+pub trait IntoSvg {
+    fn into_svg(self: Self) -> String;
+}
+
+pub mod chess;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,29 @@
-mod chess;
+use axum::{extract::Query, http::StatusCode, routing::get, Router};
+use lib_openchess::{chess::Fen, IntoBoard, IntoSvg};
+use serde::Deserialize;
 
-use axum::{http::StatusCode, routing::get, Router};
+#[derive(Deserialize)]
+struct ChessParams {
+    fen: Fen,
+}
 
 async fn healthcheck() -> StatusCode {
     StatusCode::OK
 }
 
+async fn chess(params: Query<ChessParams>) -> Result<String, String> {
+    let params = params.0;
+
+    let board = params.fen.into_board()?;
+
+    Ok(board.into_svg())
+}
+
 #[tokio::main]
 async fn main() {
-    let app = Router::new().route("/healthcheck", get(healthcheck));
+    let app = Router::new()
+        .route("/healthcheck", get(healthcheck))
+        .route("/chess", get(chess));
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await.unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ async fn chess(params: Query<ChessParams>) -> Result<String, String> {
 
     let board = params.fen.into_board()?;
 
-    Ok(board.into_svg())
+    Ok(board.into_svg(()))
 }
 
 #[tokio::main]


### PR DESCRIPTION
Separated the project into a bin, containing the web server, and a lib. 

Refactored the chess module as follows:
- Created Fen as a [new type](https://doc.rust-lang.org/rust-by-example/generics/new_types.html); I also think Fen containing a String instead of &str is necessary to make it deserializable
- Introduced IntoBoard and IntoSvg traits to allow expanding into other types of boards, when needed
- Implemented IntoBoard for Fen
- Moved piece_from_char into a method on Piece instead of Board
- Added a set_piece method to Board
- Added an empty implementation of IntoSvg to Board
- Stubbed out a route for the chess board showing the usage of the new traits; this won't work since IntoSvg isn't implemented